### PR TITLE
⚡ Bolt: Avoid redundant SELECT queries in userService

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+# Bolt's Journal
+
+## 2024-03-01 - Redundant SELECT after UPDATE
+**Learning:** Found a pattern where state mutation methods (`addBalance`, `removeBalance`, `updateUsername`) perform an `UPDATE` followed immediately by a `SELECT` to return the updated entity, even when callers don't need the updated entity. In high-frequency paths (like economy commands), this doubles the database load unnecessarily.
+**Action:** Always check if the caller actually needs the updated entity before returning it. Return the database execution result instead to save a query.

--- a/commands/economy/manageCredits.js
+++ b/commands/economy/manageCredits.js
@@ -36,18 +36,17 @@ module.exports = {
     // Asegurar registro
     await userService.createUser(targetUser.id, targetUser.username);
 
-    let updated;
     let embed;
 
     if (action === "add") {
-      updated = await userService.addBalance(targetUser.id, amount);
+      await userService.addBalance(targetUser.id, amount, false);
       embed = makeEmbed(
         "success",
         "¡Créditos añadidos!",
         `Se añadieron **${config.emojis.coin}${amount.toLocaleString()}** a <@${targetUser.id}>.`
       );
     } else if (action === "remove") {
-      updated = await userService.removeBalance(targetUser.id, amount);
+      await userService.removeBalance(targetUser.id, amount, false);
       embed = makeEmbed(
         "success",
         "¡Créditos eliminados!",

--- a/commands/economy/swap.js
+++ b/commands/economy/swap.js
@@ -133,7 +133,7 @@ module.exports.buttonHandler = async (interaction) => {
       });
     }
 
-    await userService.removeBalance(interaction.user.id, monedas);
+    await userService.removeBalance(interaction.user.id, monedas, false);
 
     try {
       await sendCommand(`cobbledollars give ${mcNick} ${cobble}`);

--- a/commands/economy/task.js
+++ b/commands/economy/task.js
@@ -12,7 +12,7 @@ async function grantReward(userId) {
   const earned = Math.floor(Math.random() * (maxEarn - minEarn + 1)) + minEarn;
   const formatted = earned.toLocaleString("es-DO");
   
-  await userService.addBalance(userId, earned);
+  await userService.addBalance(userId, earned, false);
   await logTransaction({ discordId: userId, type: "task", amount: earned });
   await cooldownService.setCooldown(userId, "trabajo", cooldown || 3600);
   

--- a/commands/economy/transfer.js
+++ b/commands/economy/transfer.js
@@ -55,8 +55,8 @@ module.exports = {
       }
 
       // 5. Ejecutar la transferencia: Remover del remitente y añadir al destinatario
-      await userService.removeBalance(senderId, amount);
-      await userService.addBalance(recipientUser.id, amount);
+      await userService.removeBalance(senderId, amount, false);
+      await userService.addBalance(recipientUser.id, amount, false);
 
       // (Opcional) 6. Registrar la transacción
       /* 

--- a/commands/games/coinflip.js
+++ b/commands/games/coinflip.js
@@ -48,7 +48,7 @@ module.exports = {
     await userService.createUser(userId, username);
 
     try {
-      await userService.addBalance(userId, -bet);
+      await userService.addBalance(userId, -bet, false);
     } catch {
       // Si falla por balance, eliminamos el cooldown que se aplicó en interactionCreate.js
       interaction.client.cooldowns.get(module.exports.data.name).delete(userId);
@@ -73,7 +73,7 @@ module.exports = {
 
     if (result === choice) {
       const reward = bet * 2;
-      await userService.addBalance(userId, reward);
+      await userService.addBalance(userId, reward, false);
 
       await transactionService.logTransaction({
         discordId: userId,

--- a/commands/games/giftbox.js
+++ b/commands/games/giftbox.js
@@ -34,7 +34,7 @@ module.exports = {
 
     try {
       // Se debita la apuesta inicial
-      await userService.addBalance(userId, -bet);
+      await userService.addBalance(userId, -bet, false);
     } catch (err) {
       return interaction.reply({
         content: "No tienes suficientes créditos.",
@@ -92,7 +92,7 @@ module.exports.buttonHandler = async (interaction) => {
       const formatted = reward.toLocaleString("es-DO");
 
       // FIX CRÍTICO: Sumar la recompensa al balance del usuario y registrar la transacción.
-      await userService.addBalance(userId, reward);
+      await userService.addBalance(userId, reward, false);
       await transactionService.logTransaction({ discordId: userId, type: "game", amount: reward });
       // FIN DEL FIX
 

--- a/commands/games/riskTower.js
+++ b/commands/games/riskTower.js
@@ -53,7 +53,7 @@ module.exports = {
     // -------------------------------------------------------------
 
     try {
-      await userService.addBalance(userId, -bet);
+      await userService.addBalance(userId, -bet, false);
     } catch (err) {
       // Si falla por balance, eliminamos el cooldown que se aplicó en interactionCreate.js
       interaction.client.cooldowns.get(module.exports.data.name).delete(userId);
@@ -166,7 +166,7 @@ module.exports.buttonHandler = async (interaction) => {
   }
 
   if (action === "cashout") {
-    await userService.addBalance(userId, current);
+    await userService.addBalance(userId, current, false);
 
     await transactionService.logTransaction({
       discordId: userId,

--- a/services/userService.js
+++ b/services/userService.js
@@ -15,9 +15,12 @@ module.exports = {
     return rows[0] || null;
   },
 
-  addBalance: async (discordId, amount) => {
+  addBalance: async (discordId, amount, returnUser = true) => {
     await db.execute("UPDATE user_stats SET balance = balance + ? WHERE discord_id = ?", [amount, discordId]);
-    return await module.exports.getUser(discordId);
+    if (returnUser) {
+      return await module.exports.getUser(discordId);
+    }
+    return null;
   },
 
   getBalance: async (discordId) => {
@@ -25,9 +28,12 @@ module.exports = {
     return user ? user.balance : 0; // Devuelve el balance o 0 si el usuario no existe.
   },
 
-  removeBalance: async (discordId, amount) => {
+  removeBalance: async (discordId, amount, returnUser = true) => {
     await db.execute("UPDATE user_stats SET balance = balance - ? WHERE discord_id = ? AND balance >= ?", [amount, discordId, amount]);
-    return await module.exports.getUser(discordId);
+    if (returnUser) {
+      return await module.exports.getUser(discordId);
+    }
+    return null;
   },
 
   updateUsername: async (discordId, newUsername) => {


### PR DESCRIPTION
### 💡 What:
Added a `returnUser` parameter to `userService.addBalance` and `userService.removeBalance` (defaulting to `true` for backward compatibility) to skip fetching the user object when it is not needed. Updated call sites in `manageCredits`, `task`, `transfer`, `swap`, `coinflip`, `riskTower`, and `giftbox` to pass `false`.

### 🎯 Why:
In high-frequency paths like economy commands and games, mutating state (`UPDATE`) was immediately followed by a `SELECT` query to return the updated user, even though callers typically ignored the returned value. This unnecessary query doubled the database read load.

### 📊 Impact:
Halves the number of database queries executed during frequent user balance updates, significantly reducing SQLite I/O and improving bot responsiveness under load.

### 🔬 Measurement:
Run the bot locally and execute economy/game commands (e.g., `/cara-cruz`, `/transferir`). The commands will function correctly, and database monitoring or query logging would show one less `SELECT` per transaction.

---
*PR created automatically by Jules for task [18403694159542695578](https://jules.google.com/task/18403694159542695578) started by @roemdev*