### PR TITLE
🛡️ Sentinel: [HIGH] Fix logic bypass in manage-credits

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - [Missing Input Boundaries on Admin Commands]
+**Vulnerability:** Admin commands that manage balances (`manageCredits.js`) lacked minimum value constraints on the amount integer parameter.
+**Learning:** Even administrative interfaces need strict boundary checking at the Discord slash command level (`.setMinValue(1)`). Otherwise, a negative input on a "remove" operation becomes addition (`balance - (-100)`), allowing an admin account to accidentally or maliciously bypass restrictions.
+**Prevention:** Always add `.setMinValue(1)` (or appropriate bounds) to numeric options in Discord.js `SlashCommandBuilder` configs, especially for economy/balance modifying endpoints.

--- a/commands/economy/manageCredits.js
+++ b/commands/economy/manageCredits.js
@@ -25,6 +25,7 @@ module.exports = {
       option.setName("amount")
         .setDescription("Cantidad de créditos")
         .setRequired(true)
+        .setMinValue(1) // Prevent negative values that could bypass restrictions
     )
     .setDefaultMemberPermissions(PermissionFlagsBits.ManageEvents),
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `/manage-credits` admin command took an `amount` integer to modify user credits but had no lower bounds. A negative value supplied to the "remove" action resulted in the equation `balance - (-100)`, effectively allowing an admin to bypass the command intent and add credits directly using the removal endpoint.
🎯 **Impact:** Compromised admins or accidental inputs could inject arbitrary credits by using negative values.
🔧 **Fix:** Added `.setMinValue(1)` on the Discord `SlashCommandBuilder` schema to ensure only positive increments are processed.
✅ **Verification:** Verified syntax manually (`node -c`). An attempt to pass `< 1` integer through the Discord UI will be natively blocked by the client before the bot processes it.

---
*PR created automatically by Jules for task [1715180434629956622](https://jules.google.com/task/1715180434629956622) started by @roemdev*