### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix negative balance bypass vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,3 +3,7 @@
 **Learning:** Even administrative interfaces need strict boundary checking at the Discord slash command level (`.setMinValue(1)`). Otherwise, a negative input on a "remove" operation becomes addition (`balance - (-100)`), allowing an admin account to accidentally or maliciously bypass restrictions.
 **Prevention:** Always add `.setMinValue(1)` (or appropriate bounds) to numeric options in Discord.js `SlashCommandBuilder` configs, especially for economy/balance modifying endpoints.
 
+## 2024-05-18 - [SQLite Silent Updates Bypass Balance Checks]
+**Vulnerability:** Game economy commands (`coinflip.js`, `giftbox.js`, `riskTower.js`) relied on `addBalance(user, -bet)` and a `try-catch` block to check for insufficient funds. However, SQLite `UPDATE` statements do not throw an error when a balance goes negative, nor does `db.run` throw an error when `changes === 0` (such as when `WHERE balance >= bet` fails). This allowed users to accrue infinite negative debt.
+**Learning:** SQLite driver `db.run` operations (or raw `UPDATE` logic) will silently succeed with `changes: 0` if conditions aren't met, or blindly allow values to drop below 0 if unsigned boundaries aren't strictly enforced.
+**Prevention:** Always manually inspect `result.changes` after an `UPDATE` operation expected to modify a record, and manually throw an error if `changes === 0`. Furthermore, sanitize `addBalance` logic to gracefully handle negative amounts using a proper `removeBalance` check.

--- a/services/userService.js
+++ b/services/userService.js
@@ -16,6 +16,11 @@ module.exports = {
   },
 
   addBalance: async (discordId, amount, returnUser = true) => {
+    // 🛡️ SECURITY ENFORCEMENT: If amount is negative, route to removeBalance
+    // This prevents SQLite from blindly updating balances to negative values and bypassing game limits
+    if (amount < 0) {
+      return await module.exports.removeBalance(discordId, Math.abs(amount), returnUser);
+    }
     await db.execute("UPDATE user_stats SET balance = balance + ? WHERE discord_id = ?", [amount, discordId]);
     if (returnUser) {
       return await module.exports.getUser(discordId);
@@ -29,7 +34,14 @@ module.exports = {
   },
 
   removeBalance: async (discordId, amount, returnUser = true) => {
-    await db.execute("UPDATE user_stats SET balance = balance - ? WHERE discord_id = ? AND balance >= ?", [amount, discordId, amount]);
+    const result = await db.execute("UPDATE user_stats SET balance = balance - ? WHERE discord_id = ? AND balance >= ?", [amount, discordId, amount]);
+
+    // 🛡️ SECURITY ENFORCEMENT: SQLite's execute does not throw an error if no rows match the WHERE clause.
+    // We must manually throw an error when changes === 0 so that try-catch blocks in games correctly fail.
+    if (result.changes === 0) {
+      throw new Error("Insufficient balance");
+    }
+
     if (returnUser) {
       return await module.exports.getUser(discordId);
     }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Several game economy commands (`coinflip.js`, `giftbox.js`, `riskTower.js`) process bets by using `addBalance(user, -bet)` wrapped in a `try/catch` block, anticipating that `addBalance` will throw an error if the user lacks sufficient funds. However, SQLite `UPDATE` operations do not throw an error if an integer value goes negative (unless explicitly constrained by `CHECK`), and `db.run` returns successfully even if `changes === 0` (e.g., when a `WHERE balance >= bet` clause fails). This allowed users with low balances to place infinite bets and accrue massive negative debt, essentially bypassing the entire economy structure.
🎯 **Impact:** Allowed infinite unbacked currency generation and gambling, completely breaking the game's economy.
🔧 **Fix:** 
1. `addBalance` now reroutes negative deposits (`amount < 0`) to `removeBalance` automatically.
2. `removeBalance` evaluates the result of the `db.execute` query. If `result.changes === 0`, it manually throws an `Error("Insufficient balance")`, ensuring the `catch` blocks in games behave properly and block execution.
✅ **Verification:** Attempting to `addBalance` with `-1000` when the user has only `50` correctly throws an error.

*Logged this pattern securely to `.jules/sentinel.md`.*

---
*PR created automatically by Jules for task [3837562138107045840](https://jules.google.com/task/3837562138107045840) started by @roemdev*