### PR TITLE
⚡ Bolt: [performance improvement] Optimize createUser to skip redundant SELECT query

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -3,3 +3,7 @@
 ## 2024-03-01 - Redundant SELECT after UPDATE
 **Learning:** Found a pattern where state mutation methods (`addBalance`, `removeBalance`, `updateUsername`) perform an `UPDATE` followed immediately by a `SELECT` to return the updated entity, even when callers don't need the updated entity. In high-frequency paths (like economy commands), this doubles the database load unnecessarily.
 **Action:** Always check if the caller actually needs the updated entity before returning it. Return the database execution result instead to save a query.
+
+## 2024-03-02 - Redundant SELECT after INSERT
+**Learning:** Found a performance bottleneck where `userService.createUser` always performed an `INSERT OR IGNORE` followed by an immediate `SELECT` (via `getUser`) to return the user object, even when callers only needed to guarantee the user's existence and ignored the returned object. In high-frequency commands like economy and games, this resulted in an unnecessary database query.
+**Action:** Modified `createUser` to accept a `returnUser` boolean parameter (defaulting to `true` for backward compatibility). Updated callers that don't need the user object (like `manageCredits`, `task`, `transfer`, `coinflip`, `giftbox`, `riskTower`) to pass `false`, skipping the redundant `SELECT` query.

--- a/commands/economy/manageCredits.js
+++ b/commands/economy/manageCredits.js
@@ -35,7 +35,7 @@ module.exports = {
     const amount = interaction.options.getInteger("amount");
 
     // Asegurar registro
-    await userService.createUser(targetUser.id, targetUser.username);
+    await userService.createUser(targetUser.id, targetUser.username, false);
 
     let embed;
 

--- a/commands/economy/task.js
+++ b/commands/economy/task.js
@@ -45,7 +45,7 @@ module.exports = {
         });
       }
 
-      await userService.createUser(userId, username);
+      await userService.createUser(userId, username, false);
 
       // Total de tareas disponibles
       const TOTAL_TASKS = 4;

--- a/commands/economy/transfer.js
+++ b/commands/economy/transfer.js
@@ -38,8 +38,8 @@ module.exports = {
     await interaction.deferReply(); // Deferir la respuesta
 
     // 2. Asegurar que ambos usuarios existan en el sistema
-    await userService.createUser(senderId, interaction.user.username);
-    await userService.createUser(recipientUser.id, recipientUser.username);
+    await userService.createUser(senderId, interaction.user.username, false);
+    await userService.createUser(recipientUser.id, recipientUser.username, false);
 
     try {
       // 3. Obtener el balance del remitente

--- a/commands/games/coinflip.js
+++ b/commands/games/coinflip.js
@@ -45,7 +45,7 @@ module.exports = {
       });
     }
 
-    await userService.createUser(userId, username);
+    await userService.createUser(userId, username, false);
 
     try {
       await userService.addBalance(userId, -bet, false);

--- a/commands/games/giftbox.js
+++ b/commands/games/giftbox.js
@@ -30,7 +30,7 @@ module.exports = {
       });
     }
 
-    await userService.createUser(userId, username);
+    await userService.createUser(userId, username, false);
 
     try {
       // Se debita la apuesta inicial

--- a/commands/games/riskTower.js
+++ b/commands/games/riskTower.js
@@ -37,7 +37,7 @@ module.exports = {
       });
     }
 
-    await userService.createUser(userId, username);
+    await userService.createUser(userId, username, false);
 
     // ✅ CORRECCIÓN DE VALIDACIÓN DE SALDO (ÚNICA MODIFICACIÓN NECESARIA)
     const currentBalance = await userService.getBalance(userId);

--- a/commands/store/buy.js
+++ b/commands/store/buy.js
@@ -64,7 +64,7 @@ module.exports = {
       });
     }
 
-    await userService.createUser(interaction.user.id, interaction.user.username);
+    await userService.createUser(interaction.user.id, interaction.user.username, false);
 
     const preview = makeEmbed(
       "info",

--- a/commands/store/store.js
+++ b/commands/store/store.js
@@ -27,7 +27,7 @@ module.exports = {
     ),
 
   async execute(interaction) {
-    await userService.createUser(interaction.user.id, interaction.user.username);
+    await userService.createUser(interaction.user.id, interaction.user.username, false);
 
     const mcNick = (interaction.options.getString("nick") || "").trim();
 

--- a/services/userService.js
+++ b/services/userService.js
@@ -1,13 +1,16 @@
 const db = require("./dbService");
 
 module.exports = {
-  createUser: async (discordId, username) => {
+  createUser: async (discordId, username, returnUser = true) => {
     // SQLite: INSERT OR IGNORE evita errores si el ID ya existe
     await db.execute(
       "INSERT OR IGNORE INTO user_stats (discord_id, username) VALUES (?, ?)",
       [discordId, username]
     );
-    return await module.exports.getUser(discordId);
+    if (returnUser) {
+      return await module.exports.getUser(discordId);
+    }
+    return null;
   },
 
   getUser: async (discordId) => {


### PR DESCRIPTION
💡 **What**: Added a `returnUser` boolean parameter (defaulting to true) to `userService.createUser`. When set to false, it skips the redundant `SELECT` query (`getUser`) executed after an `INSERT OR IGNORE`. Updated call sites that don't need the returned user object to pass false (e.g., `manageCredits`, `task`, `transfer`, `coinflip`, `giftbox`, `riskTower`).

🎯 **Why**: In high-frequency commands (like economy and gambling), calling `createUser` just to ensure the user exists would always trigger an unnecessary `SELECT` query. This optimization avoids that extra query in cases where the user object is immediately discarded.

📊 **Impact**: Saves one database read operation (`SELECT * FROM user_stats WHERE discord_id = ?`) per interaction for several heavily-used commands, directly reducing SQLite I/O overhead.

🔬 **Measurement**: Verified the changes logically. In a local testing environment, monitoring SQLite query logs would confirm that the extra `SELECT` query is no longer executed when using these commands.

Journal entry added to `.jules/bolt.md`.

---
*PR created automatically by Jules for task [9408094526462138900](https://jules.google.com/task/9408094526462138900) started by @roemdev*