### PR TITLE
🛡️ Sentinel: [HIGH] Add input validation on integer options

### DIFF
--- a/commands/economy/swap.js
+++ b/commands/economy/swap.js
@@ -16,6 +16,7 @@ module.exports = {
       option.setName("monedas")
         .setDescription("Cantidad de monedas a convertir")
         .setRequired(true)
+        .setMinValue(1)
     )
     .addStringOption(option =>
       option.setName("nick")

--- a/commands/games/coinflip.js
+++ b/commands/games/coinflip.js
@@ -21,6 +21,7 @@ module.exports = {
         .setName("cantidad")
         .setDescription("Cantidad de créditos a apostar")
         .setRequired(true)
+        .setMinValue(1)
     )
     .addStringOption(option =>
       option

--- a/commands/games/giftbox.js
+++ b/commands/games/giftbox.js
@@ -16,6 +16,7 @@ module.exports = {
         .setName("cantidad")
         .setDescription("Cantidad de créditos a apostar")
         .setRequired(true)
+        .setMinValue(1)
     ),
 
   async execute(interaction) {

--- a/commands/games/riskTower.js
+++ b/commands/games/riskTower.js
@@ -23,6 +23,7 @@ module.exports = {
         .setName("cantidad")
         .setDescription("Cantidad de créditos a apostar")
         .setRequired(true)
+        .setMinValue(1)
     ),
 
   async execute(interaction) {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Several economy and game commands (`swap`, `coinflip`, `giftbox`, `riskTower`) accepted integer options for bets and wagers without boundary validation at the command definition level. This allowed negative values or zeroes to bypass intended mathematical restrictions, which is a common vector for stealing in bot economies (e.g., losing a bet of -100 credits equates to gaining 100 credits).
🎯 **Impact:** Exploitation could allow users to generate infinite credits or break game logic without risk.
🔧 **Fix:** Implemented defense-in-depth by adding `.setMinValue(1)` directly to the `SlashCommandBuilder`'s `.addIntegerOption()` methods in `commands/economy/swap.js`, `commands/games/coinflip.js`, `commands/games/riskTower.js`, and `commands/games/giftbox.js`. This prevents Discord from even passing invalid inputs to the bot.
✅ **Verification:** Verified by inspecting the updated command configurations. Test with `node deploy-commands.js` to ensure Discord registers the min values, then attempt to execute commands with `0` or negative values (Discord UI will block it).

---
*PR created automatically by Jules for task [9993235049063420953](https://jules.google.com/task/9993235049063420953) started by @roemdev*