### PR TITLE
⚡ Bolt: [performance improvement] Reduce redundant SELECT queries in createUser

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -3,3 +3,7 @@
 ## 2024-03-01 - Redundant SELECT after UPDATE
 **Learning:** Found a pattern where state mutation methods (`addBalance`, `removeBalance`, `updateUsername`) perform an `UPDATE` followed immediately by a `SELECT` to return the updated entity, even when callers don't need the updated entity. In high-frequency paths (like economy commands), this doubles the database load unnecessarily.
 **Action:** Always check if the caller actually needs the updated entity before returning it. Return the database execution result instead to save a query.
+
+## 2024-03-05 - Redundant SELECT after INSERT OR IGNORE
+**Learning:** Similar to the mutation methods, `userService.createUser` uses `INSERT OR IGNORE` and immediately runs a `SELECT` query to fetch the user. This is often called simply to ensure a record exists before an operation, with the return value entirely discarded (e.g. in games or transactions). This creates unnecessary database queries.
+**Action:** Extend the optional `returnUser = true` pattern to creation methods like `createUser`, passing `false` in routes that do not need the database record.

--- a/commands/economy/manageCredits.js
+++ b/commands/economy/manageCredits.js
@@ -35,7 +35,7 @@ module.exports = {
     const amount = interaction.options.getInteger("amount");
 
     // Asegurar registro
-    await userService.createUser(targetUser.id, targetUser.username);
+    await userService.createUser(targetUser.id, targetUser.username, false);
 
     let embed;
 

--- a/commands/economy/task.js
+++ b/commands/economy/task.js
@@ -45,7 +45,7 @@ module.exports = {
         });
       }
 
-      await userService.createUser(userId, username);
+      await userService.createUser(userId, username, false);
 
       // Total de tareas disponibles
       const TOTAL_TASKS = 4;

--- a/commands/economy/transfer.js
+++ b/commands/economy/transfer.js
@@ -38,8 +38,8 @@ module.exports = {
     await interaction.deferReply(); // Deferir la respuesta
 
     // 2. Asegurar que ambos usuarios existan en el sistema
-    await userService.createUser(senderId, interaction.user.username);
-    await userService.createUser(recipientUser.id, recipientUser.username);
+    await userService.createUser(senderId, interaction.user.username, false);
+    await userService.createUser(recipientUser.id, recipientUser.username, false);
 
     try {
       // 3. Obtener el balance del remitente

--- a/commands/games/coinflip.js
+++ b/commands/games/coinflip.js
@@ -45,7 +45,7 @@ module.exports = {
       });
     }
 
-    await userService.createUser(userId, username);
+    await userService.createUser(userId, username, false);
 
     try {
       await userService.addBalance(userId, -bet, false);

--- a/commands/games/giftbox.js
+++ b/commands/games/giftbox.js
@@ -30,7 +30,7 @@ module.exports = {
       });
     }
 
-    await userService.createUser(userId, username);
+    await userService.createUser(userId, username, false);
 
     try {
       // Se debita la apuesta inicial

--- a/commands/games/riskTower.js
+++ b/commands/games/riskTower.js
@@ -37,7 +37,7 @@ module.exports = {
       });
     }
 
-    await userService.createUser(userId, username);
+    await userService.createUser(userId, username, false);
 
     // ✅ CORRECCIÓN DE VALIDACIÓN DE SALDO (ÚNICA MODIFICACIÓN NECESARIA)
     const currentBalance = await userService.getBalance(userId);

--- a/commands/store/buy.js
+++ b/commands/store/buy.js
@@ -64,7 +64,7 @@ module.exports = {
       });
     }
 
-    await userService.createUser(interaction.user.id, interaction.user.username);
+    await userService.createUser(interaction.user.id, interaction.user.username, false);
 
     const preview = makeEmbed(
       "info",

--- a/commands/store/store.js
+++ b/commands/store/store.js
@@ -27,7 +27,7 @@ module.exports = {
     ),
 
   async execute(interaction) {
-    await userService.createUser(interaction.user.id, interaction.user.username);
+    await userService.createUser(interaction.user.id, interaction.user.username, false);
 
     const mcNick = (interaction.options.getString("nick") || "").trim();
 

--- a/services/userService.js
+++ b/services/userService.js
@@ -1,13 +1,16 @@
 const db = require("./dbService");
 
 module.exports = {
-  createUser: async (discordId, username) => {
+  createUser: async (discordId, username, returnUser = true) => {
     // SQLite: INSERT OR IGNORE evita errores si el ID ya existe
     await db.execute(
       "INSERT OR IGNORE INTO user_stats (discord_id, username) VALUES (?, ?)",
       [discordId, username]
     );
-    return await module.exports.getUser(discordId);
+    if (returnUser) {
+      return await module.exports.getUser(discordId);
+    }
+    return null;
   },
 
   getUser: async (discordId) => {


### PR DESCRIPTION
**💡 What:**
Added an optional `returnUser` boolean parameter to `userService.createUser` (defaulting to `true`). When set to `false`, the function performs the `INSERT OR IGNORE` operation but skips the subsequent `SELECT` query (`getUser`). Updated the following command modules to pass `false` as they simply ensure the user exists but discard the returned object:
- `commands/economy/manageCredits.js`
- `commands/economy/task.js`
- `commands/economy/transfer.js`
- `commands/games/coinflip.js`
- `commands/games/riskTower.js`
- `commands/games/giftbox.js`
- `commands/store/store.js`
- `commands/store/buy.js`

**🎯 Why:**
Many commands (especially high-frequency ones like games or economy tasks) call `createUser` solely to ensure a database record exists for the user before executing logic (like deducting balances). They do not actually use the returned user object. Running an immediate `SELECT` query after the `INSERT` in these cases adds redundant I/O load to the SQLite database.

**📊 Impact:**
Reduces the number of database read queries by exactly 1 for every execution of the updated commands. In high-traffic environments, this halves the initial database impact of user initialization per command execution.

**🔬 Measurement:**
Since there is no automated test suite, verification can be done by observing the database query logs (or application profiler) while executing the updated commands (e.g., `/cara-cruz`, `/trabajo`) and confirming that only the `INSERT OR IGNORE` statement is executed, without the following `SELECT * FROM user_stats`. The functional behavior of the bot remains identical.

---
*PR created automatically by Jules for task [17233006372004202403](https://jules.google.com/task/17233006372004202403) started by @roemdev*