### PR TITLE
🛡️ Sentinel: [HIGH] Fix Auth Bypass in giftbox

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,6 +3,11 @@
 **Learning:** Even administrative interfaces need strict boundary checking at the Discord slash command level (`.setMinValue(1)`). Otherwise, a negative input on a "remove" operation becomes addition (`balance - (-100)`), allowing an admin account to accidentally or maliciously bypass restrictions.
 **Prevention:** Always add `.setMinValue(1)` (or appropriate bounds) to numeric options in Discord.js `SlashCommandBuilder` configs, especially for economy/balance modifying endpoints.
 
+## 2024-05-18 - [Discord Button Interaction Auth Bypass]
+**Vulnerability:** Game commands (`giftbox.js`) rendered interaction buttons containing game state (like user id, bet amount) but did not verify if the user clicking the button was the original user who initiated the game. This allowed any user to click another user's game buttons.
+**Learning:** Any Discord component (button, select menu) must explicitly validate authorization within its handler, because any user in the channel can theoretically interact with components attached to a message.
+**Prevention:** Always extract the original `userId` from the `customId` payload and check `if (interaction.user.id !== userId)` at the top of the component handler to prevent unauthorized interactions.
+
 ## 2024-05-18 - [SQLite Silent Updates Bypass Balance Checks]
 **Vulnerability:** Game economy commands (`coinflip.js`, `giftbox.js`, `riskTower.js`) relied on `addBalance(user, -bet)` and a `try-catch` block to check for insufficient funds. However, SQLite `UPDATE` statements do not throw an error when a balance goes negative, nor does `db.run` throw an error when `changes === 0` (such as when `WHERE balance >= bet` fails). This allowed users to accrue infinite negative debt.
 **Learning:** SQLite driver `db.run` operations (or raw `UPDATE` logic) will silently succeed with `changes: 0` if conditions aren't met, or blindly allow values to drop below 0 if unsigned boundaries aren't strictly enforced.

--- a/commands/games/giftbox.js
+++ b/commands/games/giftbox.js
@@ -84,6 +84,10 @@ module.exports.buttonHandler = async (interaction) => {
   const userId = parts[3];
   const bet = parseInt(parts[4], 10);
 
+  if (interaction.user.id !== userId) {
+    return interaction.reply({ content: "Esto no es tu juego.", ephemeral: true });
+  }
+
   if (type === "chest") {
     const winningChest = Math.floor(Math.random() * 3) + 1;
 


### PR DESCRIPTION
**🚨 Severity:** HIGH
**💡 Vulnerability:** The `giftbox.js` game command created interactive buttons with game state (e.g., bet amount, user ID) but the `buttonHandler` failed to verify if the Discord user clicking the button was the original user who initiated the game. This allowed any user to click the buttons and play another user's game.
**🎯 Impact:** Any user in the server could intercept and play a game initiated by someone else, potentially causing the original user to unexpectedly win or lose credits without their consent.
**🔧 Fix:** Added an explicit check `if (interaction.user.id !== userId)` at the beginning of the `buttonHandler` in `giftbox.js` that returns a hidden error message if the ID doesn't match the original player. Logged this pattern in `.jules/sentinel.md`.
**✅ Verification:** You can verify by starting a `/giftbox` game with one account and trying to click the buttons with a second, different Discord account. The second account should receive the "Esto no es tu juego." hidden message.

---
*PR created automatically by Jules for task [16466004839819402241](https://jules.google.com/task/16466004839819402241) started by @roemdev*