### PR TITLE
Update bot tone, UI palette, and transaction logging

### DIFF
--- a/commands/economy/coinsToCredits.js
+++ b/commands/economy/coinsToCredits.js
@@ -3,18 +3,19 @@ const { apiKey: PAYMENTER_API_KEY, url: PAYMENTER_URL } = require('../../config.
 const { coin } = require('../../core.json').emojis;
 const { SlashCommandBuilder, PermissionFlagsBits, MessageFlags, ModalBuilder, TextInputBuilder, TextInputStyle, ActionRowBuilder } = require('discord.js');
 const db = require('../../services/dbService');
+const { logTransaction } = require('../../services/transactionService');
 
 
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('monedas-a-creditos')
-    .setDescription('Convierte tus monedas del servidor a créditos en Paymenter'),
+    .setDescription('Convierte tus monedas del servidor a saldo en Paymenter'),
 
   async execute(interaction) {
     // ── Mostrar modal ───────────────────────────────────────────────────────
     const modal = new ModalBuilder()
       .setCustomId('monedas_a_creditos_modal')
-      .setTitle('Canjear monedas por créditos');
+      .setTitle('Cambiar monedas por saldo');
 
     const emailInput = new TextInputBuilder()
       .setCustomId('email_paymenter')
@@ -25,7 +26,7 @@ module.exports = {
 
     const amountInput = new TextInputBuilder()
       .setCustomId('creditos_paymenter')
-      .setLabel(`Créditos a canjear (1 = ${exchangeRate.toLocaleString()} monedas)`)
+      .setLabel(`Saldo a recibir (1 = ${exchangeRate.toLocaleString()} monedas)`)
       .setPlaceholder('Ej: 2')
       .setStyle(TextInputStyle.Short)
       .setRequired(true);
@@ -50,7 +51,7 @@ module.exports = {
 
     // Validar que la cantidad sea un número entero positivo
     if (isNaN(paymenterCredits) || paymenterCredits < 1) {
-      return interaction.editReply('❌ La cantidad de créditos debe ser un número entero mayor a 0.');
+      return interaction.editReply('Esa cantidad no me cuadra 😅. Pon un número entero mayor a 0.');
     }
 
     try {
@@ -63,7 +64,7 @@ module.exports = {
 
       if (currentBalance < costInCoins) {
         return interaction.editReply(
-          `❌ No tienes suficientes monedas. Balance actual: **${currentBalance.toLocaleString()}** ${coin} | Necesitas: **${costInCoins.toLocaleString()}** ${coin}.`
+          `No te alcanza por ahora 😬. Tienes **${currentBalance.toLocaleString()}** ${coin} y necesitas **${costInCoins.toLocaleString()}** ${coin}.`
         );
       }
 
@@ -77,7 +78,7 @@ module.exports = {
       });
 
       if (!getResponse.ok) {
-        return interaction.editReply(`❌ No se pudo conectar con Paymenter (Código: ${getResponse.status}).`);
+        return interaction.editReply(`No pude hablar con Paymenter (${getResponse.status}). Intenta en un ratito.`);
       }
 
       const usersData = await getResponse.json();
@@ -89,7 +90,7 @@ module.exports = {
       });
 
       if (!targetPaymenterUser) {
-        return interaction.editReply(`❌ No se encontró ninguna cuenta con el correo **${paymenterEmail}**.`);
+        return interaction.editReply(`No encontré ninguna cuenta con el correo **${paymenterEmail}**.`);
       }
 
       const paymenterId = targetPaymenterUser.attributes?.id ?? targetPaymenterUser.id;
@@ -118,7 +119,7 @@ module.exports = {
 
         if (!alreadyExists) {
           console.error(`[exchange-paymenter] Error credits POST ${creditResponse.status}:`, errBody);
-          return interaction.editReply(`❌ Falló la entrega de créditos en Paymenter (Código: ${creditResponse.status}).`);
+          return interaction.editReply(`Paymenter rechazó el saldo (${creditResponse.status}).`);
         }
 
         // Buscar registro existente y sumar
@@ -133,7 +134,7 @@ module.exports = {
         );
 
         if (!listRes.ok) {
-          return interaction.editReply('❌ No se pudo obtener el registro de créditos existente.');
+          return interaction.editReply('No pude cargar tu registro de saldo en Paymenter.');
         }
 
         const creditsList  = await listRes.json();
@@ -143,7 +144,7 @@ module.exports = {
         });
 
         if (!existingCredit) {
-          return interaction.editReply('❌ No se encontró el registro de créditos del usuario.');
+          return interaction.editReply('No encontré tu registro de saldo en Paymenter.');
         }
 
         const creditId  = existingCredit.id;
@@ -168,7 +169,7 @@ module.exports = {
         if (!creditResponse.ok) {
           const putErr = await creditResponse.text();
           console.error(`[exchange-paymenter] Error credits PUT ${creditResponse.status}:`, putErr);
-          return interaction.editReply(`❌ Falló la actualización de créditos en Paymenter (Código: ${creditResponse.status}).`);
+          return interaction.editReply(`No pude actualizar el saldo en Paymenter (${creditResponse.status}).`);
         }
       }
 
@@ -177,14 +178,21 @@ module.exports = {
         'UPDATE user_stats SET balance = balance - ? WHERE discord_id = ?',
         [costInCoins, targetUser.id]
       );
+      await logTransaction({
+        discordId: targetUser.id,
+        type: 'coins_to_credits',
+        itemName: `Canje a Paymenter (${paymenterEmail})`,
+        amount: costInCoins,
+        totalPrice: paymenterCredits
+      });
 
       return interaction.editReply(
-        `✅ ¡Canje exitoso! Se descontaron **${costInCoins.toLocaleString()}** ${coin} monedas y se añadieron **${paymenterCredits}** crédito(s) a la cuenta **${paymenterEmail}** en Paymenter.`
+        `¡Canje listo! Desconté **${costInCoins.toLocaleString()}** ${coin} y envié saldo a **${paymenterEmail}** en Paymenter.`
       );
 
     } catch (error) {
       console.error('[exchange-paymenter] Error general:', error);
-      return interaction.editReply('❌ Ocurrió un error interno al procesar la operación.');
+      return interaction.editReply('Se me enredó el canje 😵. Inténtalo de nuevo en un momento.');
     }
   }
 };

--- a/commands/economy/manageCredits.js
+++ b/commands/economy/manageCredits.js
@@ -1,12 +1,13 @@
-const { SlashCommandBuilder, PermissionFlagsBits, MessageFlags } = require("discord.js");
+const { SlashCommandBuilder, PermissionFlagsBits } = require("discord.js");
 const userService = require("../../services/userService");
-const { makeContainer, CV2 } = require("../../utils/ui");
+const transactionService = require("../../services/transactionService");
+const { CV2 } = require("../../utils/ui");
 const config = require("../../core.json");
 
 module.exports = {
   data: new SlashCommandBuilder()
     .setName("manage-credits")
-    .setDescription("Gestiona los créditos de un usuario")
+    .setDescription("Gestiona las monedas de un usuario")
     .addStringOption((opt) =>
       opt
         .setName("action")
@@ -18,7 +19,7 @@ module.exports = {
       opt.setName("user").setDescription("Usuario a modificar").setRequired(true)
     )
     .addIntegerOption((opt) =>
-      opt.setName("amount").setDescription("Cantidad de créditos").setRequired(true).setMinValue(1)
+      opt.setName("amount").setDescription("Cantidad de monedas").setRequired(true).setMinValue(1)
     )
     .setDefaultMemberPermissions(PermissionFlagsBits.ManageEvents),
 
@@ -32,16 +33,28 @@ module.exports = {
 
     if (action === "add") {
       await userService.addBalance(target.id, amount, false);
+      await transactionService.logTransaction({
+        discordId: target.id,
+        type: "admin_add",
+        itemName: `Ajuste por ${interaction.user.username}`,
+        amount,
+      });
       return interaction.reply({
-        components: [makeContainer("success", "Créditos añadidos", `Se añadieron **${coin}${amount.toLocaleString()}** a <@${target.id}>.`)],
+        content: `Listo, sumé **${coin}${amount.toLocaleString()}** a <@${target.id}>.`,
         flags: CV2,
       });
     }
 
     if (action === "remove") {
       await userService.removeBalance(target.id, amount, false);
+      await transactionService.logTransaction({
+        discordId: target.id,
+        type: "admin_remove",
+        itemName: `Ajuste por ${interaction.user.username}`,
+        amount,
+      });
       return interaction.reply({
-        components: [makeContainer("success", "Créditos eliminados", `Se eliminaron **${coin}${amount.toLocaleString()}** de <@${target.id}>.`)],
+        content: `Hecho, retiré **${coin}${amount.toLocaleString()}** de <@${target.id}>.`,
         flags: CV2,
       });
     }

--- a/commands/economy/transfer.js
+++ b/commands/economy/transfer.js
@@ -1,18 +1,18 @@
 const { SlashCommandBuilder } = require("discord.js");
 const userService = require("../../services/userService");
 const transactionService = require("../../services/transactionService");
-const { makeContainer, CV2, CV2_EPHEMERAL } = require("../../utils/ui");
+const { CV2, CV2_EPHEMERAL } = require("../../utils/ui");
 const config = require("../../core.json");
 
 module.exports = {
   data: new SlashCommandBuilder()
     .setName("transferir")
-    .setDescription("Transfiere créditos de tu balance a otro usuario")
+    .setDescription("Envía monedas de tu balance a otro usuario")
     .addUserOption((opt) =>
-      opt.setName("destino").setDescription("El usuario al que deseas enviar créditos").setRequired(true)
+      opt.setName("destino").setDescription("Usuario al que le vas a enviar monedas").setRequired(true)
     )
     .addIntegerOption((opt) =>
-      opt.setName("cantidad").setDescription("Cantidad de créditos a transferir").setRequired(true).setMinValue(1)
+      opt.setName("cantidad").setDescription("Cantidad de monedas a transferir").setRequired(true).setMinValue(1)
     ),
 
   async execute(interaction) {
@@ -22,10 +22,7 @@ module.exports = {
     const coin = config.emojis.coin;
 
     if (senderId === recipient.id) {
-      return interaction.reply({
-        components: [makeContainer("error", "Error", "No puedes transferirte créditos a ti mismo.")],
-        flags: CV2_EPHEMERAL,
-      });
+      return interaction.reply({ content: "Eh pillín, no te puedes transferir monedas a ti mismo 😄.", flags: CV2_EPHEMERAL });
     }
 
     await interaction.deferReply();
@@ -37,13 +34,7 @@ module.exports = {
 
       if (senderBalance < amount) {
         return interaction.editReply({
-          components: [
-            makeContainer(
-              "error",
-              "Saldo insuficiente",
-              `Tu balance de ${coin}${senderBalance.toLocaleString()} no es suficiente para enviar ${coin}${amount.toLocaleString()}.`
-            ),
-          ],
+          content: `Te faltan monedas 😅. Tienes ${coin}${senderBalance.toLocaleString()} y querías enviar ${coin}${amount.toLocaleString()}.`,
           flags: CV2,
         });
       }
@@ -55,29 +46,25 @@ module.exports = {
         discordId: senderId,
         type: "transfer_out",
         itemName: `Transferencia a ${recipient.username}`,
+        amount,
         totalPrice: amount,
       });
       await transactionService.logTransaction({
         discordId: recipient.id,
         type: "transfer_in",
         itemName: `Transferencia de ${interaction.user.username}`,
+        amount,
         totalPrice: amount,
       });
 
       return interaction.editReply({
-        components: [
-          makeContainer(
-            "success",
-            "Transferencia exitosa",
-            `Enviaste **${coin}${amount.toLocaleString()}** a <@${recipient.id}>.\nNuevo balance: ${coin}${(senderBalance - amount).toLocaleString()}.`
-          ),
-        ],
+        content: `¡Listo! Le mandaste **${coin}${amount.toLocaleString()}** a <@${recipient.id}>.\nTe quedan ${coin}${(senderBalance - amount).toLocaleString()}.`,
         flags: CV2,
       });
     } catch (error) {
       console.error(error);
       return interaction.editReply({
-        components: [makeContainer("error", "Error del sistema", "Hubo un error al procesar la transferencia.")],
+        content: "Ups, la transferencia se tropezó en el camino. Inténtalo otra vez.",
         flags: CV2,
       });
     }

--- a/commands/games/coinflip.js
+++ b/commands/games/coinflip.js
@@ -47,7 +47,7 @@ module.exports = {
     const choiceText = choice === "heads" ? "CARA" : "CRUZ";
 
     const pendingContainer = new ContainerBuilder()
-        .setAccentColor(0xf0c040)
+        .setAccentColor(0x6C3483)
         .addTextDisplayComponents(t =>
             t.setContent(`### 🪙 Cara o Cruz\nApostaste ${COIN}**${bet.toLocaleString()}** a **${choiceText}**.\nLanzando moneda...`)
         );
@@ -65,7 +65,7 @@ module.exports = {
       await transactionService.logTransaction({ discordId: userId, type: "game", amount: reward });
 
       const winContainer = new ContainerBuilder()
-          .setAccentColor(0x32cd32)
+          .setAccentColor(0xF4C542)
           .addTextDisplayComponents(t =>
               t.setContent(`### 🎉 ¡Ganaste!\nApostaste ${COIN}**${bet.toLocaleString()}** a **${choiceText}** — salió **${resultText}**.\nGanaste ${COIN}**${reward.toLocaleString()}**.`)
           );
@@ -75,7 +75,7 @@ module.exports = {
       await transactionService.logTransaction({ discordId: userId, type: "game", amount: 0 });
 
       const loseContainer = new ContainerBuilder()
-          .setAccentColor(0xff4500)
+          .setAccentColor(0xC0392B)
           .addTextDisplayComponents(t =>
               t.setContent(`### 💸 Perdiste\nApostaste ${COIN}**${bet.toLocaleString()}** a **${choiceText}** — salió **${resultText}**.\nMás suerte la próxima vez.`)
           );

--- a/commands/games/giftbox.js
+++ b/commands/games/giftbox.js
@@ -32,7 +32,7 @@ module.exports = {
     }
 
     const container = new ContainerBuilder()
-        .setAccentColor(0x9b59b6)
+        .setAccentColor(0x6C3483)
         .addTextDisplayComponents(t =>
             t.setContent(
                 `### 🎁 ¡Prueba tu suerte!\n` +
@@ -69,7 +69,7 @@ module.exports.buttonHandler = async (interaction) => {
     await transactionService.logTransaction({ discordId: userId, type: "game", amount: reward });
 
     const winContainer = new ContainerBuilder()
-        .setAccentColor(0x32cd32)
+        .setAccentColor(0xF4C542)
         .addTextDisplayComponents(t =>
             t.setContent(`### 🎉 ¡Ganaste!\nElegiste la caja correcta y ganaste ${COIN}**${reward.toLocaleString()}**. ¡Sigue jugando!`)
         );
@@ -79,7 +79,7 @@ module.exports.buttonHandler = async (interaction) => {
     await transactionService.logTransaction({ discordId: userId, type: "game", amount: 0 });
 
     const loseContainer = new ContainerBuilder()
-        .setAccentColor(0xff4500)
+        .setAccentColor(0xC0392B)
         .addTextDisplayComponents(t =>
             t.setContent(`### ❌ ¡Perdiste!\nEl premio estaba en la caja **${winningChest}**. Perdiste ${COIN}**${bet.toLocaleString()}**. ¡Vuelve a intentarlo!`)
         );

--- a/commands/games/riskTower.js
+++ b/commands/games/riskTower.js
@@ -42,7 +42,7 @@ module.exports = {
 
 function buildTowerPanel(userId, bet, current) {
   return new ContainerBuilder()
-      .setAccentColor(0x9b59b6)
+      .setAccentColor(0x6C3483)
       .addTextDisplayComponents(t =>
           t.setContent(
               `### 🗼 Torre de Riesgo\n` +
@@ -84,7 +84,7 @@ module.exports.buttonHandler = async (interaction) => {
       const next = current * 1.25;
 
       const winContainer = new ContainerBuilder()
-          .setAccentColor(0x32cd32)
+          .setAccentColor(0xF4C542)
           .addTextDisplayComponents(t =>
               t.setContent(
                   `### 🚀 ¡Subiste un nivel!\n` +
@@ -104,7 +104,7 @@ module.exports.buttonHandler = async (interaction) => {
       await transactionService.logTransaction({ discordId: userId, type: "game", amount: 0 });
 
       const loseContainer = new ContainerBuilder()
-          .setAccentColor(0xff4500)
+          .setAccentColor(0xC0392B)
           .addTextDisplayComponents(t =>
               t.setContent(`### 💥 Todo perdido\nLa torre colapsó. Perdiste ${COIN}**${current.toLocaleString()}** créditos.`)
           );
@@ -118,7 +118,7 @@ module.exports.buttonHandler = async (interaction) => {
     await transactionService.logTransaction({ discordId: userId, type: "game", amount: current });
 
     const cashoutContainer = new ContainerBuilder()
-        .setAccentColor(0x32cd32)
+        .setAccentColor(0xF4C542)
         .addTextDisplayComponents(t =>
             t.setContent(`### 💰 Cobro realizado\nTe retiraste a tiempo. Conservaste ${COIN}**${current.toLocaleString()}** créditos.`)
         );

--- a/commands/games/smash.js
+++ b/commands/games/smash.js
@@ -68,7 +68,7 @@ function buildPanel(session) {
       : `🔒 **Apuestas cerradas** — Bote total: ${COIN}${totalPot.toLocaleString()}`;
 
   const container = new ContainerBuilder()
-      .setAccentColor(0xe74c3c)
+      .setAccentColor(0xC0392B)
       .addTextDisplayComponents(t =>
           t.setContent(
               `### 🎮 Smash Bros — Torneo de Apuestas\nHosteado por <@${session.hostId}>\n\n${statusLine}\n\n${characterLines.join("\n")}`
@@ -108,7 +108,7 @@ module.exports = {
       if (s.hostId === hostId && s.open) {
         return interaction.reply({
           components: [
-            new ContainerBuilder().setAccentColor(0xff4500)
+            new ContainerBuilder().setAccentColor(0xC0392B)
                 .addTextDisplayComponents(t => t.setContent("### ❌ Sesión activa\nCierra la sesión anterior antes de abrir una nueva."))
           ],
           flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
@@ -156,7 +156,7 @@ module.exports = {
       if (!session || !session.open) {
         return interaction.reply({
           components: [
-            new ContainerBuilder().setAccentColor(0xff4500)
+            new ContainerBuilder().setAccentColor(0xC0392B)
                 .addTextDisplayComponents(t => t.setContent("### 🔒 Sesión cerrada\nLas apuestas ya están cerradas."))
           ],
           flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
@@ -174,7 +174,7 @@ module.exports = {
         } catch {
           return interaction.reply({
             components: [
-              new ContainerBuilder().setAccentColor(0xff4500)
+              new ContainerBuilder().setAccentColor(0xC0392B)
                   .addTextDisplayComponents(t => t.setContent(`### ❌ Saldo insuficiente\nNecesitas ${config.emojis.coin}${BET_INCREMENT.toLocaleString()} para aumentar tu apuesta.`))
             ],
             flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
@@ -188,7 +188,7 @@ module.exports = {
 
         return interaction.reply({
           components: [
-            new ContainerBuilder().setAccentColor(0x32cd32)
+            new ContainerBuilder().setAccentColor(0xF4C542)
                 .addTextDisplayComponents(t => t.setContent(`### ✅ Apuesta aumentada\nTu apuesta total es ahora ${config.emojis.coin}${bettor.amount.toLocaleString()} en **${charName}**.`))
           ],
           flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
@@ -216,7 +216,7 @@ module.exports = {
       if (!session) {
         return interaction.reply({
           components: [
-            new ContainerBuilder().setAccentColor(0xff4500)
+            new ContainerBuilder().setAccentColor(0xC0392B)
                 .addTextDisplayComponents(t => t.setContent("### ❌ No encontrada\nEsta sesión ya no existe."))
           ],
           flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
@@ -226,7 +226,7 @@ module.exports = {
       if (interaction.user.id !== session.hostId) {
         return interaction.reply({
           components: [
-            new ContainerBuilder().setAccentColor(0xff4500)
+            new ContainerBuilder().setAccentColor(0xC0392B)
                 .addTextDisplayComponents(t => t.setContent("### 🚫 Sin permiso\nSolo el hoster puede cerrar las apuestas."))
           ],
           flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
@@ -236,7 +236,7 @@ module.exports = {
       if (!session.open) {
         return interaction.reply({
           components: [
-            new ContainerBuilder().setAccentColor(0xf0c040)
+            new ContainerBuilder().setAccentColor(0x5B7FA6)
                 .addTextDisplayComponents(t => t.setContent("### ℹ️ Ya cerrado\nLas apuestas ya estaban cerradas."))
           ],
           flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
@@ -251,7 +251,7 @@ module.exports = {
 
       return interaction.reply({
         components: [
-          new ContainerBuilder().setAccentColor(0x32cd32)
+          new ContainerBuilder().setAccentColor(0xF4C542)
               .addTextDisplayComponents(t => t.setContent("### ✅ Apuestas cerradas\nUsa `/smash-resultado` para declarar el personaje ganador cuando termine el juego."))
         ],
         flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
@@ -271,7 +271,7 @@ module.exports = {
     if (!session || !session.open) {
       return interaction.reply({
         components: [
-          new ContainerBuilder().setAccentColor(0xff4500)
+          new ContainerBuilder().setAccentColor(0xC0392B)
               .addTextDisplayComponents(t => t.setContent("### 🔒 Sesión cerrada\nLas apuestas ya están cerradas."))
         ],
         flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
@@ -282,7 +282,7 @@ module.exports = {
     if (session.bettors.has(userId)) {
       return interaction.reply({
         components: [
-          new ContainerBuilder().setAccentColor(0xf0c040)
+          new ContainerBuilder().setAccentColor(0x5B7FA6)
               .addTextDisplayComponents(t => t.setContent("### ℹ️ Ya apostaste\nUsa el botón de apostar directamente para sumar a tu apuesta."))
         ],
         flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
@@ -293,7 +293,7 @@ module.exports = {
     if (!char) {
       return interaction.reply({
         components: [
-          new ContainerBuilder().setAccentColor(0xff4500)
+          new ContainerBuilder().setAccentColor(0xC0392B)
               .addTextDisplayComponents(t => t.setContent(`### ❌ No encontrado\nNo se encontró ningún personaje asociado a "${inputField.value}". Intenta escribir el nombre completo.`))
         ],
         flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
@@ -304,7 +304,7 @@ module.exports = {
     if (!uniqueChars.has(char.id) && uniqueChars.size >= 8) {
       return interaction.reply({
         components: [
-          new ContainerBuilder().setAccentColor(0xff4500)
+          new ContainerBuilder().setAccentColor(0xC0392B)
               .addTextDisplayComponents(t => t.setContent("### ❌ Límite alcanzado\nYa se apostó al límite de 8 personajes. Escoge uno de los que ya participan."))
         ],
         flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
@@ -317,7 +317,7 @@ module.exports = {
     } catch {
       return interaction.reply({
         components: [
-          new ContainerBuilder().setAccentColor(0xff4500)
+          new ContainerBuilder().setAccentColor(0xC0392B)
               .addTextDisplayComponents(t => t.setContent(`### ❌ Saldo insuficiente\nNecesitas ${config.emojis.coin}${BET_INCREMENT.toLocaleString()} para apostar.`))
         ],
         flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
@@ -331,7 +331,7 @@ module.exports = {
 
     return interaction.reply({
       components: [
-        new ContainerBuilder().setAccentColor(0x32cd32)
+        new ContainerBuilder().setAccentColor(0xF4C542)
             .addTextDisplayComponents(t => t.setContent(`### ✅ ¡Apuesta registrada!\nApostaste ${config.emojis.coin}${BET_INCREMENT.toLocaleString()} a **${char.name}**.`))
       ],
       flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,

--- a/commands/games/smashResult.js
+++ b/commands/games/smashResult.js
@@ -23,7 +23,7 @@ module.exports = {
     if (!winnerChar) {
       return interaction.reply({
         components: [
-          new ContainerBuilder().setAccentColor(0xff4500)
+          new ContainerBuilder().setAccentColor(0xC0392B)
               .addTextDisplayComponents(t => t.setContent(`### ❌ Personaje no encontrado\nNo se encontró ningún personaje asociado a "${winnerInput}". Escribe el nombre o alias correctamente.`))
         ],
         flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
@@ -45,7 +45,7 @@ module.exports = {
     if (!session) {
       return interaction.reply({
         components: [
-          new ContainerBuilder().setAccentColor(0xff4500)
+          new ContainerBuilder().setAccentColor(0xC0392B)
               .addTextDisplayComponents(t => t.setContent("### ❌ Sin sesión activa\nNo tienes ninguna sesión de apuestas cerrada pendiente de resultado."))
         ],
         flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
@@ -75,7 +75,7 @@ module.exports = {
 
       return interaction.editReply({
         components: [
-          new ContainerBuilder().setAccentColor(0xf0c040)
+          new ContainerBuilder().setAccentColor(0x5B7FA6)
               .addTextDisplayComponents(t => t.setContent(
                   `### ${winnerChar.emoji} ${winnerChar.name} ganó — sin apostadores\n` +
                   `Nadie apostó por **${winnerChar.name}**. El bote de ${COIN}${totalPot.toLocaleString()} fue al hoster.`
@@ -99,7 +99,7 @@ module.exports = {
 
     return interaction.editReply({
       components: [
-        new ContainerBuilder().setAccentColor(0x32cd32)
+        new ContainerBuilder().setAccentColor(0xF4C542)
             .addTextDisplayComponents(t => t.setContent(
                 `### ${winnerChar.emoji} ${winnerChar.name} ganó\n\n` +
                 `**Bote total:** ${COIN}${totalPot.toLocaleString()}\n` +

--- a/commands/store/add-item.js
+++ b/commands/store/add-item.js
@@ -26,7 +26,7 @@ module.exports = {
 
       await interaction.editReply({
         components: [
-          new ContainerBuilder().setAccentColor(0x32cd32)
+          new ContainerBuilder().setAccentColor(0xF4C542)
               .addTextDisplayComponents(t => t.setContent(
                   `### ✅ Artículo añadido\n**${icono} ${nombre}** agregado a la tienda por **${precio}** monedas.\nComando MC: \`give <jugador> ${mcItem}\``
               ))
@@ -37,7 +37,7 @@ module.exports = {
       console.error("Error al añadir item:", error);
       await interaction.editReply({
         components: [
-          new ContainerBuilder().setAccentColor(0xff4500)
+          new ContainerBuilder().setAccentColor(0xC0392B)
               .addTextDisplayComponents(t => t.setContent("### ❌ Error al guardar\nOcurrió un problema al guardar el artículo en la base de datos."))
         ],
         flags: MessageFlags.IsComponentsV2,

--- a/commands/store/buy.js
+++ b/commands/store/buy.js
@@ -24,7 +24,7 @@ module.exports = {
     if (!isValidMinecraftNick(mcNick)) {
       return interaction.reply({
         components: [
-          new ContainerBuilder().setAccentColor(0xff4500)
+          new ContainerBuilder().setAccentColor(0xC0392B)
               .addTextDisplayComponents(t => t.setContent("### ❌ Nickname inválido\nEl nickname de Minecraft proporcionado no es válido."))
         ],
         flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
@@ -35,7 +35,7 @@ module.exports = {
     if (!item || item.status !== "available") {
       return interaction.reply({
         components: [
-          new ContainerBuilder().setAccentColor(0xff4500)
+          new ContainerBuilder().setAccentColor(0xC0392B)
               .addTextDisplayComponents(t => t.setContent("### ❌ No disponible\nEl artículo solicitado no está disponible."))
         ],
         flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
@@ -50,7 +50,7 @@ module.exports = {
     );
 
     const preview = new ContainerBuilder()
-        .setAccentColor(0x3498db)
+        .setAccentColor(0x1E8449)
         .addTextDisplayComponents(t => t.setContent(
             `### 🛒 Confirmar compra\n` +
             `Artículo: **${item.icon_id} ${item.name}**\n` +
@@ -66,7 +66,7 @@ module.exports = {
     return interaction.reply({
       components: [
         new ContainerBuilder()
-            .setAccentColor(0x3498db)
+            .setAccentColor(0x1E8449)
             .addTextDisplayComponents(t => t.setContent(
                 `### 🛒 Confirmar compra\n` +
                 `Artículo: **${item.icon_id} ${item.name}**\n` +
@@ -118,7 +118,7 @@ module.exports = {
     if (action === "cancel") {
       return interaction.editReply({
         components: [
-          new ContainerBuilder().setAccentColor(0xf0c040)
+          new ContainerBuilder().setAccentColor(0x1E8449)
               .addTextDisplayComponents(t => t.setContent("### ℹ️ Compra cancelada\nNo se procesó ninguna transacción."))
         ],
         flags: MessageFlags.IsComponentsV2,
@@ -140,7 +140,7 @@ module.exports = {
 
         return interaction.editReply({
           components: [
-            new ContainerBuilder().setAccentColor(0x32cd32)
+            new ContainerBuilder().setAccentColor(0xF4C542)
                 .addTextDisplayComponents(t => t.setContent("### ✅ Compra realizada con éxito\nEl artículo ha sido entregado en Minecraft."))
           ],
           flags: MessageFlags.IsComponentsV2,
@@ -148,7 +148,7 @@ module.exports = {
       } catch (err) {
         return interaction.editReply({
           components: [
-            new ContainerBuilder().setAccentColor(0xff4500)
+            new ContainerBuilder().setAccentColor(0xC0392B)
                 .addTextDisplayComponents(t => t.setContent(`### ❌ Error en la compra\n${err.message}`))
           ],
           flags: MessageFlags.IsComponentsV2,

--- a/commands/store/store.js
+++ b/commands/store/store.js
@@ -22,7 +22,7 @@ module.exports = {
     if (!isValidMinecraftNick(mcNick)) {
       return interaction.reply({
         components: [
-          new ContainerBuilder().setAccentColor(0xff4500)
+          new ContainerBuilder().setAccentColor(0xC0392B)
               .addTextDisplayComponents(t => t.setContent("### ❌ Nickname inválido\nEl nickname de Minecraft proporcionado no es válido."))
         ],
         flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
@@ -35,7 +35,7 @@ module.exports = {
     if (!items || items.length === 0) {
       return interaction.editReply({
         components: [
-          new ContainerBuilder().setAccentColor(0xf0c040)
+          new ContainerBuilder().setAccentColor(0x1E8449)
               .addTextDisplayComponents(t => t.setContent("### 🛒 Tienda vacía\nNo hay items disponibles actualmente."))
         ],
         flags: MessageFlags.IsComponentsV2,
@@ -43,7 +43,7 @@ module.exports = {
     }
 
     const storeContainer = new ContainerBuilder()
-        .setAccentColor(0x3498db)
+        .setAccentColor(0x1E8449)
         .addTextDisplayComponents(t => t.setContent(`### 🛒 Tienda | Nick: \`${mcNick}\`\nSelecciona el artículo que deseas comprar.`))
         .addSeparatorComponents(s => s);
 
@@ -88,7 +88,7 @@ module.exports = {
       if (!item || item.status !== "available") {
         return interaction.editReply({
           components: [
-            new ContainerBuilder().setAccentColor(0xff4500)
+            new ContainerBuilder().setAccentColor(0xC0392B)
                 .addTextDisplayComponents(t => t.setContent("### ❌ No disponible\nEl artículo ya no está disponible."))
           ],
           flags: MessageFlags.IsComponentsV2,
@@ -107,7 +107,7 @@ module.exports = {
 
       return interaction.editReply({
         components: [
-          new ContainerBuilder().setAccentColor(0x32cd32)
+          new ContainerBuilder().setAccentColor(0xF4C542)
               .addTextDisplayComponents(t => t.setContent(
                   `### ✅ ¡Compra realizada!\nHas comprado **${result.item.icon_id} ${result.item.name}** para **${mcNick}** por ${COIN}${result.totalPrice.toLocaleString()}.`
               ))
@@ -117,7 +117,7 @@ module.exports = {
     } catch (err) {
       return interaction.editReply({
         components: [
-          new ContainerBuilder().setAccentColor(0xff4500)
+          new ContainerBuilder().setAccentColor(0xC0392B)
               .addTextDisplayComponents(t => t.setContent(`### ❌ Error en la compra\n${err.message}`))
         ],
         flags: MessageFlags.IsComponentsV2,

--- a/commands/utility/ping.js
+++ b/commands/utility/ping.js
@@ -13,7 +13,7 @@ module.exports = {
     await interaction.editReply({
       content: "",
       components: [
-        new ContainerBuilder().setAccentColor(0x3498db)
+        new ContainerBuilder().setAccentColor(0x5B7FA6)
             .addTextDisplayComponents(t => t.setContent(
                 `### 🏓 Pong!\n**Latencia WebSocket:** ${wsPing}ms\n**Latencia de interacción:** ${interactionPing}ms`
             ))

--- a/commands/utility/setup-colors.js
+++ b/commands/utility/setup-colors.js
@@ -21,7 +21,7 @@ const BUTTON_STYLES = {
 
 function buildColorsPanel() {
   const container = new ContainerBuilder()
-      .setAccentColor(0x9b59b6)
+      .setAccentColor(0x5B7FA6)
       .addTextDisplayComponents(t =>
           t.setContent(
               "### 🎨 Roles de Color\n" +

--- a/commands/utility/setupVoice.js
+++ b/commands/utility/setupVoice.js
@@ -17,7 +17,7 @@ module.exports = {
 
   async execute(interaction) {
     const panel = new ContainerBuilder()
-        .setAccentColor(0x5865f2)
+        .setAccentColor(0x5B7FA6)
         .addTextDisplayComponents(t =>
             t.setContent(
                 "### 🎙️ Panel de Control de Voz\n" +

--- a/core.json
+++ b/core.json
@@ -4,7 +4,7 @@
     "currency": "USD"
   },
   "emojis": {
-    "coin": "`🪙`"
+    "coin": "🪙"
   },
   "tasks": {
     "minEarn": 3000,

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -29,7 +29,7 @@ module.exports = {
           );
           if (!interaction.replied && !interaction.deferred) {
             await interaction.reply({
-              content: "Hubo un error al procesar el formulario.",
+              content: "Uy, ese formulario salió travieso. Prueba otra vez.",
               flags: MessageFlags.Ephemeral,
             });
           }
@@ -58,7 +58,7 @@ module.exports = {
           );
           if (!interaction.replied && !interaction.deferred) {
             await interaction.reply({
-              content: "Hubo un error al procesar este botón.",
+              content: "Ese botón se puso rebelde 😅. Inténtalo de nuevo.",
               flags: MessageFlags.Ephemeral,
             });
           }
@@ -81,7 +81,7 @@ module.exports = {
           );
           if (!interaction.replied && !interaction.deferred) {
             await interaction.reply({
-              content: "Hubo un error al procesar esta selección.",
+              content: "Esa selección se enredó un poquito. Dale otra vez.",
               flags: MessageFlags.Ephemeral,
             });
           }
@@ -118,7 +118,7 @@ module.exports = {
         if (now < expirationTime) {
           const expiredTimestamp = Math.round(expirationTime / 1_000);
           return interaction.reply({
-            content: `Please wait, you are on a cooldown for \`${command.data.name}\`. You can use it again <t:${expiredTimestamp}:R>.`,
+            content: `Tranqui, crack 😎. Ese comando está descansando y vuelve <t:${expiredTimestamp}:R>.`,
             flags: MessageFlags.Ephemeral,
           });
         }
@@ -134,7 +134,7 @@ module.exports = {
       }
     } catch (error) {
       console.error(error);
-      const errorMessage = "There was an error while executing this command!";
+      const errorMessage = "Ay no, este comando tropezó 😵. Intenta otra vez.";
       if (interaction.replied || interaction.deferred) {
         await interaction.followUp({
           content: errorMessage,


### PR DESCRIPTION
### Motivation
- Unificar el tono de los mensajes a un estilo cálido e informal y usar siempre “monedas” como unidad visible. 
- Corregir el formato del emoji moneda en `core.json` para evitar backticks. 
- Registrar las transacciones que faltaban para mantener trazabilidad financiera. 
- Aplicar la nueva paleta de colores a las respuestas interactivas sin cambiar la lógica.

### Description
- Actualicé `core.json` para que `emojis.coin` sea `"🪙"` (sin backticks). 
- Reescribí y traduje varios mensajes visibles al usuario siguiendo el nuevo tono (cálido, informal, confirmaciones cortas y errores cariñosos) incluyendo el mensaje de cooldown en `events/interactionCreate.js`. 
- Añadí llamadas a `logTransaction(...)` con metadata apropiada en `commands/economy/transfer.js` (`transfer_out` / `transfer_in` + `amount`), `commands/economy/manageCredits.js` (`admin_add` / `admin_remove` + `amount`), y `commands/economy/coinsToCredits.js` (`coins_to_credits` con `itemName`, `amount`, `totalPrice`). 
- Mantuve la regla visual: todo lo interactivo (juegos, tienda, panel de voz, colores) sigue usando `ContainerBuilder`, y todas las respuestas del bot (confirmaciones, errores, info) se entregan ahora en texto plano cuando corresponde (no embeds). 
- Apliqué la paleta de colores nueva en los `ContainerBuilder` para los comandos relevantes usando estos valores: éxito `0xF4C542`, error `0xC0392B`, info/neutral `0x5B7FA6`, juegos/apuestas `0x6C3483`, tienda `0x1E8449`, y cambié los acentos en `commands/games/*`, `commands/store/*` y `commands/utility/*` (ej.: `coinflip`, `giftbox`, `smash`, `tienda`, `comprar`, `setup-voice`, `setup-colors`, `ping`).

### Testing
- Ejecuté comprobación de sintaxis con `node --check` sobre los archivos modificados (`transfer.js`, `manageCredits.js`, `coinsToCredits.js`, `events/interactionCreate.js`, `store/*`, `games/*`, `utility/*`) y no se reportaron errores. 
- Ejecuté `npm test` y falló por falta de suite de tests en el proyecto (`Error: no test specified`), lo cual es esperado y no está relacionado con los cambios introducidos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc0d3237448331bcf7001cb88829e3)